### PR TITLE
Add "Send To Owners" transaction type

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Not all features described in this document are active by default. Each feature 
 + Smart property features are unlocked as of block #297110
 + Managed Token-pool Smart Property features are unlocked as of block #323230
 + Pay-to-script-hash address support is unlocked as of block #322000
++ Send To Owners transaction type is unlocked as of block #342650
 
 ## Transaction versioning
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,41 @@ Say you want to transfer 1 Mastercoin to another address. Only 16 bytes are need
 |Currency identifier| [Currency identifier](#field-currency-identifier) |1 (Mastercoin)|
 |Amount to transfer|[Number of Coins](#field-number-of-coins)|100,000,000 (1.0 coins) |
 
+### Send To Owners
+
+Description: Transaction type 3 transfers coins in the specified currency from the sending address to the current owners of that currency. The current owners are all the addresses, excluding the sender's address, that have a non-zero balance of the specified currency when the transaction message is processed. The Amount to transfer must be divided proportionally among the current owners based upon each owner's current available balance plus reserved amount, excluding the amount owned by the sender.
+
+The sending address must be charged a transfer fee for each address that receives coins as a result of this transaction. The fee is:
+* 0.00000001 Mastercoins for currencies in the MSC ecosystem, and 
+* 0.00000001 Test Mastercoins for currencies in the Test MSC ecosystem.
+
+See [Currency Identifier](#field-currency-identifier), above.
+
+Be aware that some owners of the specified currency might receive zero coins due to rounding in calculating the number of coins for each owner. See the Implementation Note below.
+
+This transaction can not be used to transfer bitcoins.
+
+In addition to the validity constraints on the message field datatypes, the transaction is invalid if any of the following conditions is true:
+* the sending address has zero coins in its available balance for the specified currency identifier
+* the amount to transfer exceeds the number owned and available by the sending address
+* the specified currency identifier is non-existent
+* the specified currency identifier is 0 (bitcoin)
+* the sending address does not have a sufficient available balance to pay the transfer fee
+* the sending address owns all the coins of the specified currency identifier
+
+Implementation Note: It is possible, even likely, that the number of coins calculated to be transferred to an owner's address will have to be rounded to comply with the precision for representing quantities of that coin. To reward the owners of the largest quantities and to try to ensure they receive full distributions, the following method must be used: compute the amount for the largest holder and, if necessary, round that amount up to the nearest unit that can be represented for the currency. Then subtract that rounded amount from the total to be distributed and repeat for the next largest holder until there are no more coins to be distributed. This means that holders of lesser amounts might receive zero coins from the distribution. When there are multiple owners with exactly the same number of coins, compute the distributions to those in alphabetical order by address.
+
+Say you have grown wealthy and wish to gift all 1000 of your own Quantum Miner digital tokens to the other people holding those tokens. The message to do so will use 16 bytes:
+
+1. [Transaction version](#field-transaction-version) = 0
+1. [Transaction type](#field-transaction-type) = 3
+2. [Currency identifier](#field-currency-identifier) = 6 for Quantum Miner Tokens
+3. [Amount to transfer](#field-number-of-coins) = 100,000,000,000 (1000.00000000 Quantum Miner Tokens)
+
+The protocol will split up the 1000 Quantum Miner tokens and send them to the other holders of those tokens, according to how many tokens they have.
+
+Note to users: please make sure your proposed use case is legal in your jurisdiction!!
+
 
 ## Distributed Exchange
 


### PR DESCRIPTION
"Send To Owners" is implemented and live on mainnet, and therefore qualified for the "implemented" branch.